### PR TITLE
feat: Support date type field and add guard for association audit [WS-41187]

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -116,9 +116,9 @@ module Audited
 
       def create_audit(attributes = {})
         # convert Time to Integer since dynamoDB use timestamp
-        attributes[:audited_changes] = attributes[:audited_changes]&.transform_values do |value|
-          value.is_a?(Time) ? value.to_i : value
-        end
+        # read more: https://aws.amazon.com/blogs/database/working-with-date-and-timestamp-data-types-in-amazon-dynamodb/
+        attributes[:audited_changes] = deep_transform_audited_value(attributes[:audited_changes])
+
         Audited.audit_class.create(attributes.merge(auditable_id: id, auditable_type: self.class.name))
       end
 
@@ -302,6 +302,21 @@ module Audited
         changes
       end
 
+      def deep_transform_audited_value(obj)
+        case obj
+        when Hash
+          obj.transform_values { |v| deep_transform_audited_value(v) }
+        when Array
+          obj.map { |v| deep_transform_audited_value(v) }
+        when Date
+          obj.iso8601
+        when Time
+          obj.to_i
+        else
+          obj
+        end
+      end
+
       def normalize_time_changes(changes)
         changes.each do |name, value|
           if value.is_a?(Array)
@@ -392,8 +407,10 @@ module Audited
         if auditing_enabled
           if audit_associated_with.present?
             associated_record = send(audit_associated_with)
-            attrs[:associated_id] = associated_record.id
-            attrs[:associated_type] = associated_record.class.name
+            if associated_record
+              attrs[:associated_id] = associated_record.id
+              attrs[:associated_type] = associated_record.class.name
+            end
           end
 
           run_callbacks(:audit) {


### PR DESCRIPTION
### What’s Changed

https://workstreamhq.atlassian.net/browse/WS-41187

This PR addresses [two issues](https://app.circleci.com/pipelines/github/helloworld1812/workstream-backend/74202/workflows/b025921c-9991-4d65-8c08-cca9e150d007/jobs/121906/parallel-runs/8?filterBy=FAILED) encountered when auditing models with dynamo-audited in backend:

1. Incompatible Attribute Types:
    - Problem: Saving Date or Time values inside audited_changes causes `ArgumentError: unsupported type`
    - Fix: Transform all Date values into ISO-8601 strings (e.g. "2025-06-09"), and convert Time into integer UNIX timestamps to maintain its current behaviour.
2. Nil Associated Records:
    - Problem: When audited `associated_with: :offer` is used, and the `offer` is nil, `write_audit` throws NoMethodError when calling `associated_record.id`.
    - Fix: Add a presence check before trying to access id or class.name on the associated record. If the association is nil, skip setting associated_id and associated_type.