### PR TITLE
Add support for Rails 8.0/8.1 and optimize performance

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,4 +1,4 @@
-ruby_version: 3.1
+ruby_version: 3.4
 ignore:
   - lib/generators/audited/templates/**/*
   - vendor/bundle/**/*

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,4 +1,4 @@
-ruby_version: 2.3
+ruby_version: 3.1
 ignore:
   - lib/generators/audited/templates/**/*
   - vendor/bundle/**/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+## Overview
+
+**dynamo-audited** is a Rails audit logging gem that stores audit trails in DynamoDB via the [Dynamoid](https://github.com/Dynamoid/dynamoid) ORM. It's forked from [audited](https://github.com/collectiveidea/audited) v5.7.0 and adapted for DynamoDB-backed storage instead of relational tables.
+
+## Commands
+
+### Testing
+
+```bash
+# Run all tests (requires DynamoDB Local on http://localhost:8000 and PostgreSQL)
+bundle exec rake spec
+
+# Run a single spec file
+bundle exec rspec spec/audited/auditor_spec.rb
+
+# Run a single example by line number
+bundle exec rspec spec/audited/auditor_spec.rb:42
+
+# Run tests against a specific Rails version
+appraisal rails72 bundle exec rake spec
+```
+
+### Linting
+
+```bash
+bundle exec standardrb            # check style (uses standard gem)
+bundle exec standardrb --fix      # auto-fix style issues
+```
+
+### Building
+
+```bash
+rake build    # creates pkg/dynamo-audited-*.gem
+```
+
+### Multi-version test matrix (Appraisals)
+
+Appraisals cover Rails 5.2, 6.0, 6.1, 7.0, 7.1, 7.2. To install and run:
+```bash
+appraisal install
+appraisal rails72 rake spec
+```
+
+## Architecture
+
+### Core flow
+
+```
+ActiveRecord model
+  → .audited(options)          # AuditedClassMethods mixes in callbacks
+  → AuditedInstanceMethods     # audit_create / audit_update / audit_destroy / audit_touch
+  → DynamoAudit.create(...)    # Dynamoid document stored in DynamoDB
+```
+
+Request context (current user, remote IP, request UUID) is captured by `Audited::Sweeper`, an `around_action` automatically added to `ActionController::Base` and `ActionController::API` via the Railtie. Context is stored in `ActiveSupport::CurrentAttributes` (wrapped by `Audited::Store`).
+
+### Key files
+
+| File | Responsibility |
+|------|---------------|
+| `lib/audited.rb` | Module config, `Audited::Store` (CurrentAttributes wrapper), global defaults |
+| `lib/audited/auditor.rb` | `AuditedClassMethods` (`.audited` macro, enable/disable) + `AuditedInstanceMethods` (callbacks, `revisions`, `revision_at`, `without_auditing`) |
+| `lib/audited/dynamo_audit.rb` | Dynamoid model; GSIs for auditable lookup and associated-model lookup; `revision`, `undo`, `ancestors` |
+| `lib/audited/sweeper.rb` | Controller `around_action` that populates `Audited::Store` per request |
+| `lib/audited/railtie.rb` | Auto-registers Sweeper into Rails controllers |
+| `lib/audited/rspec_matchers.rb` | `be_audited` / `have_associated_audits` RSpec DSL |
+
+### DynamoDB table layout
+
+`DynamoAudit` uses:
+- Primary key: `id` (hash) + `created_at` (range)
+- GSI `auditable_id_version_index`: hash=`auditable_id`, range=`version` — used for per-record audit lookup
+- GSI `associated_id_associated_type_index`: hash=`associated_id`, range=`associated_type` — used for `has_associated_audits`
+
+### Configuration (host app)
+
+```ruby
+Audited.config do |config|
+  config.current_user_method = :current_user       # controller method for user
+  config.current_user_attributes = [:id, :email]   # attributes to snapshot from user
+  config.ignored_attributes = %w[updated_at]       # globally ignored fields
+  config.max_audits = 100                          # prune old audits above this count
+  config.audit_class = Audited::DynamoAudit        # override audit model
+end
+```
+
+### Model usage
+
+```ruby
+class Article < ApplicationRecord
+  audited only: [:title, :body], redacted: [:secret], max_audits: 50
+  has_associated_audits
+end
+```
+
+### Test infrastructure
+
+Tests use a minimal Rails app at `spec/rails_app/` backed by PostgreSQL (for auditable ActiveRecord models) and DynamoDB Local (`http://localhost:8000`) for audit storage. Test models are defined in `spec/support/active_record/models.rb`. DynamoDB is configured via `spec/rails_app/config/initializers/dynamoid.rb`.

--- a/Appraisals
+++ b/Appraisals
@@ -1,46 +1,41 @@
-# Include DB adapters matching the version requirements in
-# rails/activerecord/lib/active_record/connection_adapters/*adapter.rb
-
 appraise "rails52" do
   gem "rails", "~> 5.2.8"
-  gem "mysql2", ">= 0.4.4", "< 0.6.0"
   gem "pg", ">= 0.18", "< 2.0"
-  gem "sqlite3", "~> 1.3.6"
   gem "psych", "~> 3.1"
   gem "loofah", "2.20.0"
 end
 
 appraise "rails60" do
   gem "rails", "~> 6.0.6"
-  gem "mysql2", ">= 0.4.4"
   gem "pg", ">= 0.18", "< 2.0"
-  gem "sqlite3", "~> 1.4"
 end
 
 appraise "rails61" do
   gem "rails", "~> 6.1.7"
-  gem "mysql2", ">= 0.4.4"
   gem "pg", ">= 1.1", "< 2.0"
-  gem "sqlite3", "~> 1.4"
 end
 
 appraise "rails70" do
   gem "rails", "~> 7.0.8"
-  gem "mysql2", ">= 0.4.4"
   gem "pg", ">= 1.1"
-  gem "sqlite3", "~> 1.4"
 end
 
 appraise "rails71" do
   gem "rails", "~> 7.1.3"
-  gem "mysql2", ">= 0.4.4"
   gem "pg", ">= 1.1"
-  gem "sqlite3", "~> 1.4"
 end
 
 appraise "rails72" do
   gem "rails", "~> 7.2.0"
-  gem "mysql2", "~> 0.5"
   gem "pg", "~> 1.1"
-  gem "sqlite3", ">= 1.4"
+end
+
+appraise "rails80" do
+  gem "rails", "~> 8.0.0"
+  gem "pg", "~> 1.1"
+end
+
+appraise "rails81" do
+  gem "rails", "~> 8.1.0"
+  gem "pg", "~> 1.1"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-# Audited ChangeLog
+# Dynamo Audited ChangeLog
+
+⚠️ **After 5.7.0, the gem is completely decoupled from upstream [audited](https://github.com/collectiveidea/audited)
+It was forked from the original audited gem and switched to the dynamodb adapter.**
+
+So the changelogs below are for the workstrem own `dynamo-audited` changelog
+
+### 6.0.0 (2025-03-27)
+- Upgrade to Ruby 3.4.4
+- Support for Rails 8.0, 8.1
+- Upgrade dynamoid to 3.12.1
+
+### 5.8.0 (2024-10)
+- Use the dynamodb adapter
+
+---
+Archived changelogs from upstream projects can be found in the [upstream changelog](https://github.com/collectiveidea/audited/blob/v5.7.0/CHANGELOG.md).
 
 ### 5.7.0 (2024-08-13)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+@AGENTS.md
+
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -14,18 +14,18 @@ Gem::Specification.new do |gem|
 
   gem.files = `git ls-files`.split($\).reject { |f| f =~ /^(\.gemspec|\.git|\.standard|\.yard|gemfiles|test|spec)/ }
 
-  gem.required_ruby_version = ">= 2.3.0"
+  gem.required_ruby_version = ">= 3.1.0"
 
-  gem.add_dependency "activerecord", ">= 5.2", "< 8.0"
-  gem.add_dependency "activesupport", ">= 5.2", "< 8.0"
+  gem.add_dependency "activerecord", ">= 5.2", "< 8.2"
+  gem.add_dependency "activesupport", ">= 5.2", "< 8.2"
   gem.add_dependency "dynamoid"
 
   gem.add_development_dependency "appraisal"
-  gem.add_development_dependency "rails", ">= 5.2", "< 8.0"
+  gem.add_development_dependency "rails", ">= 5.2", "< 8.2"
   gem.add_development_dependency "rspec-rails"
   gem.add_development_dependency "standard"
   gem.add_development_dependency "single_cov"
 
   gem.add_development_dependency "pg", ">= 0.18", "< 2.0"
-  gem.add_development_dependency  "aws-sdk"
+  gem.add_development_dependency "aws-sdk"
 end

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -3,10 +3,8 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.8"
-gem "mysql2", ">= 0.4.4", "< 0.6.0"
 gem "pg", ">= 0.18", "< 2.0"
-gem "sqlite3", "~> 1.3.6"
 gem "psych", "~> 3.1"
 gem "loofah", "2.20.0"
 
-gemspec name: "audited", path: "../"
+gemspec name: "dynamo-audited", path: "../"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -3,8 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0.6"
-gem "mysql2", ">= 0.4.4"
 gem "pg", ">= 0.18", "< 2.0"
-gem "sqlite3", "~> 1.4"
 
-gemspec name: "audited", path: "../"
+gemspec name: "dynamo-audited", path: "../"

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -3,8 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.7"
-gem "mysql2", ">= 0.4.4"
 gem "pg", ">= 1.1", "< 2.0"
-gem "sqlite3", "~> 1.4"
 
-gemspec name: "audited", path: "../"
+gemspec name: "dynamo-audited", path: "../"

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -3,8 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.1.3"
-gem "mysql2", ">= 0.4.4"
 gem "pg", ">= 1.1"
-gem "sqlite3", "~> 1.4"
 
-gemspec name: "audited", path: "../"
+gemspec name: "dynamo-audited", path: "../"

--- a/gemfiles/rails72.gemfile
+++ b/gemfiles/rails72.gemfile
@@ -3,8 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.2.0"
-gem "mysql2", "~> 0.5"
 gem "pg", "~> 1.1"
-gem "sqlite3", ">= 1.4"
 
-gemspec name: "audited", path: "../"
+gemspec name: "dynamo-audited", path: "../"

--- a/gemfiles/rails80.gemfile
+++ b/gemfiles/rails80.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0.8"
-gem "pg", ">= 1.1"
+gem "rails", "~> 8.0.0"
+gem "pg", "~> 1.1"
 
 gemspec name: "dynamo-audited", path: "../"

--- a/gemfiles/rails81.gemfile
+++ b/gemfiles/rails81.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0.8"
-gem "pg", ">= 1.1"
+gem "rails", "~> 8.1.0"
+gem "pg", "~> 1.1"
 
 gemspec name: "dynamo-audited", path: "../"

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -31,7 +31,7 @@ module Audited
     # remove audit_model in next major version it was only shortly present in 5.1.0
     alias_method :audit_model, :audit_class
     deprecate audit_model: "use Audited.audit_class instead of Audited.audit_model. This method will be removed.",
-              deprecator: ActiveSupport::Deprecation.new('6.0.0', 'Audited')
+      deprecator: ActiveSupport::Deprecation.new("6.0.0", "Audited")
 
     def store
       RequestStore.audited_store ||= {}

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -60,7 +60,7 @@ module Audited
       #
       def audited(options = {})
         # don't allow multiple calls
-        return if included_modules.include?(Audited::Auditor::AuditedInstanceMethods)
+        return if include?(Audited::Auditor::AuditedInstanceMethods)
 
         extend Audited::Auditor::AuditedClassMethods
         include Audited::Auditor::AuditedInstanceMethods
@@ -197,7 +197,7 @@ module Audited
 
       # Returns a list combined of record audits and associated audits.
       def own_and_associated_audits
-        (Audited.audit_class.where(auditable_id: self.id, auditable_type: self.class.name).to_a +
+        (Audited.audit_class.where(auditable_id: id, auditable_type: self.class.name).to_a +
           Audited.audit_class.where(associated_id: id, associated_type: self.class.name).to_a).sort_by(&:created_at).reverse
       end
 
@@ -258,7 +258,7 @@ module Audited
 
         all_changes = all_changes.except(*self.class.readonly_attributes.to_a) if exclude_readonly_attrs
 
-        filtered_changes = \
+        filtered_changes =
           if audited_options[:only].present?
             all_changes.slice(*self.class.audited_columns)
           else
@@ -271,11 +271,11 @@ module Audited
         if for_touch && (last_audit = audits.last&.audited_changes)
           filtered_changes.reject! do |k, v|
             last_audit[k].to_json == v.to_json ||
-            last_audit[k].to_json == v[1].to_json ||
-            # handle BigDecimal and Integer/Float comparison
-            (last_audit[k].is_a?(BigDecimal) && last_audit[k] == v[1].to_d) ||
-            (last_audit[k].is_a?(Array) && last_audit[k][0].is_a?(BigDecimal) &&
-              last_audit[k] == v.map(&:to_d))
+              last_audit[k].to_json == v[1].to_json ||
+              # handle BigDecimal and Integer/Float comparison
+              (last_audit[k].is_a?(BigDecimal) && last_audit[k] == v[1].to_d) ||
+              (last_audit[k].is_a?(Array) && last_audit[k][0].is_a?(BigDecimal) &&
+                last_audit[k] == v.map(&:to_d))
           end
         end
 
@@ -289,7 +289,7 @@ module Audited
 
         self.class.defined_enums.each do |name, values|
           if changes.has_key?(name)
-            changes[name] = \
+            changes[name] =
               if changes[name].is_a?(Array)
                 changes[name].map { |v| values[v] }
               elsif rails_below?("5.0")
@@ -320,7 +320,7 @@ module Audited
       def normalize_time_changes(changes)
         changes.each do |name, value|
           if value.is_a?(Array)
-            changes[name] = value.map{|v| v.is_a?(Time) ? v.to_i : v }
+            changes[name] = value.map { |v| v.is_a?(Time) ? v.to_i : v }
           end
         end
         changes
@@ -462,7 +462,7 @@ module Audited
       end
 
       CALLBACKS.each do |attr_name|
-        alias_method "#{attr_name}_callback".to_sym, attr_name
+        alias_method :"#{attr_name}_callback", attr_name
       end
 
       def auditing_enabled

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -208,13 +208,11 @@ module Audited
         combine_target.comment = "#{combine_target.comment}\nThis audit is the result of multiple audits being combined."
 
         transaction do
-          begin
-            combine_target.save!
-            audits_to_combine.where("version.lt": combine_target.version).delete_all
-          rescue ActiveRecord::Deadlocked
-            # Ignore Deadlocks, if the same record is getting its old audits combined more than once at the same time then
-            # both combining operations will be the same. Ignoring this error allows one of the combines to go through successfully.
-          end
+          combine_target.save!
+          audits_to_combine.where("version.lt": combine_target.version).delete_all
+        rescue ActiveRecord::Deadlocked
+          # Ignore Deadlocks, if the same record is getting its old audits combined more than once at the same time then
+          # both combining operations will be the same. Ignoring this error allows one of the combines to go through successfully.
         end
       end
 
@@ -381,7 +379,7 @@ module Audited
       end
 
       def audit_update
-        unless (changes = audited_changes(exclude_readonly_attrs: true)).empty? && (audit_comment.blank? || audited_options[:update_with_comment_only] == false)
+        if !(changes = audited_changes(exclude_readonly_attrs: true)).empty? || !(audit_comment.blank? || audited_options[:update_with_comment_only] == false)
           write_audit(action: "update", audited_changes: changes,
             comment: audit_comment)
         end

--- a/lib/audited/dynamo_audit.rb
+++ b/lib/audited/dynamo_audit.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 module Audited
   class DynamoAudit
     include Dynamoid::Document

--- a/lib/audited/dynamo_audit.rb
+++ b/lib/audited/dynamo_audit.rb
@@ -183,7 +183,7 @@ module Audited
       if action == "create"
         self.version = 1
       else
-        audit_with_max_version = self.class.auditable_finder(auditable_id, auditable_type)&.sort_by(&:version)&.last
+        audit_with_max_version = self.class.auditable_finder(auditable_id, auditable_type)&.max_by(&:version)
         self.version = (audit_with_max_version&.version || 0) + 1
       end
     end

--- a/lib/audited/dynamo_audit.rb
+++ b/lib/audited/dynamo_audit.rb
@@ -31,7 +31,7 @@ module Audited
     cattr_accessor :audited_class_names
     self.audited_class_names = Set.new
 
-    before_create :set_version_number, :set_request_uuid, :set_remote_address, :set_audit_user
+    before_create :set_created_at, :set_version_number, :set_request_uuid, :set_remote_address, :set_audit_user
 
     class << self
       # class methods to replace active record scope and association
@@ -158,7 +158,7 @@ module Audited
         Audited.current_user_attributes.each do |attribute|
           value = user.send(attribute)
           # convert id to string, otherwise bigint ID will be read as BigDecimal
-          normalized_value = attribute.to_s == 'id' ? value.to_s : value
+          normalized_value = (attribute.to_s == "id") ? value.to_s : value
           user_attr[attribute] = normalized_value
         end
         self.user_attributes = user_attr
@@ -174,6 +174,10 @@ module Audited
     alias_method :audited_changes, :audited_changes_indifferent
 
     private
+
+    def set_created_at
+      self.created_at ||= Time.current
+    end
 
     def set_version_number
       if action == "create"

--- a/lib/audited/version.rb
+++ b/lib/audited/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Audited
-  VERSION = "5.8.0"
+  VERSION = "6.0.0"
 end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -1,9 +1,10 @@
 require "spec_helper"
 
-# not testing proxy_respond_to? hack / 2 methods / deprecation of `version`
+# not testing proxy_respond_to? hack (L242)
+# dead code on Rails 8: changes fallback (L256), rails_below?("5.0") (L296),
+# normalize_time_changes non-array else (L322), encrypted_attributes else (L340)
 # also, an additional 6 around `after_touch` for Versions before 6.
-# Increased to 17/10 to get to green CI as a new baseline, August 2024.
-uncovered = (ActiveRecord::VERSION::MAJOR < 6) ? 17 : 10
+uncovered = (ActiveRecord::VERSION::MAJOR < 6) ? 17 : 5
 SingleCov.covered! uncovered: uncovered
 
 class ConditionalPrivateCompany < ::ActiveRecord::Base
@@ -56,6 +57,25 @@ end
 class InclusiveCompany2 < ::ActiveRecord::Base
   self.table_name = "companies"
   audited unless: proc { false }
+end
+
+class UnknownConditionCompany < ::ActiveRecord::Base
+  self.table_name = "companies"
+  audited if: :nonexistent_condition_method
+end
+
+class ProcMaxAuditsUser < ::ActiveRecord::Base
+  self.table_name = "users"
+  audited max_audits: -> { 2 }
+end
+
+class SymbolMaxAuditsUser < ::ActiveRecord::Base
+  self.table_name = "users"
+  audited max_audits: :audit_limit
+
+  def audit_limit
+    2
+  end
 end
 
 class Secret < ::ActiveRecord::Base
@@ -144,6 +164,16 @@ describe Audited::Auditor do
           it { is_expected.to be_truthy }
         end
       end
+    end
+
+    it "should not re-include modules when audited is called twice on the same class" do
+      modules_before = Models::ActiveRecord::User.included_modules.length
+      Models::ActiveRecord::User.audited
+      expect(Models::ActiveRecord::User.included_modules.length).to eq(modules_before)
+    end
+
+    it "should still audit when condition method does not exist on the model" do
+      expect { UnknownConditionCompany.create!(name: "Test") }.to change(Audited::DynamoAudit, :count).by(1)
     end
 
     it "should be configurable which attributes are not audited via ignored_attributes" do
@@ -322,6 +352,12 @@ describe Audited::Auditor do
 
     it "should store enum value" do
       expect(user.audits.first.audited_changes["status"]).to eq(1)
+    end
+
+    it "should serialize Date values as ISO8601 strings" do
+      date = Date.new(2024, 6, 15)
+      user = Models::ActiveRecord::User.create!(name: "Dated", hired_on: date)
+      expect(user.audits.first.audited_changes["hired_on"]).to eq("2024-06-15")
     end
 
     context "when store_synthesized_enums is set to true" do
@@ -620,6 +656,12 @@ describe Audited::Auditor do
       owned_company.destroy
       expect(owned_company.audits.last.associated).to eq(owner)
     end
+
+    it "should not set associated_id when associated record is nil" do
+      company = Models::ActiveRecord::OwnedCompany.new(name: "No Owner")
+      company.save(validate: false)
+      expect(company.audits.last.associated_id).to be_nil
+    end
   end
 
   describe "has associated audits" do
@@ -629,6 +671,10 @@ describe Audited::Auditor do
     it "should list the associated audits" do
       expect(owner.associated_audits.count).to eq(1)
       expect(owner.associated_audits.first.auditable).to eq(owned_company)
+    end
+
+    it "should return empty array for unsaved records" do
+      expect(Models::ActiveRecord::Owner.new.associated_audits).to eq([])
     end
   end
 
@@ -678,6 +724,20 @@ describe Audited::Auditor do
         expect(audits.to_a[1].audited_changes).to eq({"activated" => [nil, true]})
         expect(audits.to_a[2].audited_changes).to eq({"favourite_device" => [nil, "Android Phone"]})
       end
+    end
+
+    it "should support a Proc for max_audits" do
+      user = ProcMaxAuditsUser.create!(name: "Test")
+      user.update!(name: "Update 1")
+      user.update!(name: "Update 2")
+      expect(user.audits.count).to eq(2)
+    end
+
+    it "should support a Symbol for max_audits" do
+      user = SymbolMaxAuditsUser.create!(name: "Test")
+      user.update!(name: "Update 1")
+      user.update!(name: "Update 2")
+      expect(user.audits.count).to eq(2)
     end
 
     it "should add comment line for combined audit" do
@@ -873,10 +933,10 @@ describe Audited::Auditor do
     let(:user) { create_user }
 
     it "should find the latest revision before the given time" do
-      allow(DateTime).to receive(:now).and_return(1.hour.ago)
-      expect(user.audits.count).to eq(1)
+      travel_to(1.hour.ago) do
+        expect(user.audits.count).to eq(1)
+      end
 
-      allow(DateTime).to receive(:now).and_return(DateTime.current)
       user.update! name: "updated"
       expect(user.revision_at(2.minutes.ago).audit_version).to eq(1)
     end
@@ -948,6 +1008,14 @@ describe Audited::Auditor do
         Audited.auditing_enabled = true
         expect(Models::ActiveRecord::User.auditing_enabled).to eql(true)
       end
+    end
+
+    it "should not re-enable auditing if it was already disabled before the block" do
+      Models::ActiveRecord::User.disable_auditing
+      Models::ActiveRecord::User.without_auditing {}
+      expect(Models::ActiveRecord::User.auditing_enabled).to eq(false)
+    ensure
+      Models::ActiveRecord::User.enable_auditing
     end
 
     it "should reset auditing status even it raises an exception" do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -278,21 +278,21 @@ describe Audited::Auditor do
 
     context "when ignored_default_callbacks is set" do
       before { Audited.ignored_default_callbacks = [:create] }
-      after { Audited.ignored_default_callbacks = [] }
+      after do
+        Audited.ignored_default_callbacks = []
+        Audited.audit_class.audited_class_names.delete("DefaultCallback")
+        Audited.audit_class.audited_class_names.delete("CallbacksSpecified")
+      end
 
       it "should remove create callback" do
-        class DefaultCallback < ::ActiveRecord::Base
-          audited
-        end
-
+        stub_const("DefaultCallback", Class.new(::ActiveRecord::Base))
+        DefaultCallback.audited
         expect(DefaultCallback.audited_options[:on]).to eq([:update, :touch, :destroy])
       end
 
       it "should keep create callback if specified" do
-        class CallbacksSpecified < ::ActiveRecord::Base
-          audited on: [:create, :update, :destroy]
-        end
-
+        stub_const("CallbacksSpecified", Class.new(::ActiveRecord::Base))
+        CallbacksSpecified.audited(on: [:create, :update, :destroy])
         expect(CallbacksSpecified.audited_options[:on]).to eq([:create, :update, :destroy])
       end
     end
@@ -340,7 +340,7 @@ describe Audited::Auditor do
 
     it "should set the action to create" do
       expect(user.audits.first.action).to eq("create")
-      expect(Audited::DynamoAudit.where(action: "create").sort_by(&:created_at).last).to eq(user.audits.first)
+      expect(Audited::DynamoAudit.where(action: "create").max_by(&:created_at)).to eq(user.audits.first)
       expect(user.audits.where(action: "create").count).to eq(1)
       expect(user.audits.where(action: "update").count).to eq(0)
       expect(user.audits.where(action: "destroy").count).to eq(0)
@@ -408,7 +408,7 @@ describe Audited::Auditor do
     it "should set the action to 'update'" do
       @user.update! name: "Changed"
       expect(@user.audits.last.action).to eq("update")
-      expect(Audited::DynamoAudit.where(action: "update").sort_by(&:created_at).last).to eq(@user.audits.last)
+      expect(Audited::DynamoAudit.where(action: "update").max_by(&:created_at)).to eq(@user.audits.last)
       expect(@user.audits.where(action: "update").last).to eq(@user.audits.last)
     end
 
@@ -479,7 +479,7 @@ describe Audited::Auditor do
       it "should set the action to 'update'" do
         @user.touch(:suspended_at)
         expect(@user.audits.last.action).to eq("update")
-        expect(Audited::DynamoAudit.where(action: "update").sort_by(&:created_at).last).to eq(@user.audits.last)
+        expect(Audited::DynamoAudit.where(action: "update").max_by(&:created_at)).to eq(@user.audits.last)
         expect(@user.audits.where(action: "update").last).to eq(@user.audits.last)
       end
 
@@ -584,7 +584,7 @@ describe Audited::Auditor do
       @user.destroy
 
       expect(@user.audits.last.action).to eq("destroy")
-      expect(Audited::DynamoAudit.where(action: "destroy").sort_by(&:created_at).last).to eq(@user.audits.last)
+      expect(Audited::DynamoAudit.where(action: "destroy").max_by(&:created_at)).to eq(@user.audits.last)
       expect(@user.audits.where(action: "destroy").last).to eq(@user.audits.last)
     end
 

--- a/spec/audited/dynamo_audit_spec.rb
+++ b/spec/audited/dynamo_audit_spec.rb
@@ -112,7 +112,7 @@ describe Audited::DynamoAudit do
         :core_company_id,
         :auth_token
       ]
-      tableless_user = Models::TablelessModel::User.new(id: 12345, core_company_id: 123, auth_token: 'token')
+      tableless_user = Models::TablelessModel::User.new(id: 12345, core_company_id: 123, auth_token: "token")
       subject.user = tableless_user
       expect(subject.user.id).to eq(tableless_user.id.to_s)
       expect(subject.user.core_company_id).to eq(tableless_user.core_company_id)

--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -28,6 +28,7 @@ end
 
 describe AuditsController do
   include RSpec::Rails::ControllerExampleGroup
+
   render_views
 
   before do

--- a/spec/audited_spec.rb
+++ b/spec/audited_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Audited do
   describe "#store" do
     describe "maintains state of store" do
-      let(:current_user) { Models::ActiveRecord::User.new(name: 'Some User', username: 'some_username') }
+      let(:current_user) { Models::ActiveRecord::User.new(name: "Some User", username: "some_username") }
 
       it "can store and retrieve current_user" do
         expect(Audited.store[:current_user]).to be_nil

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -24,7 +24,7 @@ module RailsApp
         ActiveSupport::TimeZone,
         ActiveSupport::HashWithIndifferentAccess
       ]
-    elsif !Rails.version.start_with?("5.0") && !Rails.version.start_with?("5.1") && config.active_record.respond_to?(:yaml_column_permitted_classes=)
+    elsif !Rails.version.start_with?("5.0", "5.1") && config.active_record.respond_to?(:yaml_column_permitted_classes=)
       config.active_record.yaml_column_permitted_classes =
         %w[String Symbol Integer NilClass Float Time Date FalseClass Hash Array DateTime TrueClass BigDecimal
           ActiveSupport::TimeWithZone ActiveSupport::TimeZone ActiveSupport::HashWithIndifferentAccess]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,15 @@ Dir[SPEC_ROOT.join("support/*.rb")].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include AuditedSpecHelpers
+  config.include ActiveSupport::Testing::TimeHelpers
   config.use_transactional_fixtures = false if Rails.version.start_with?("4.")
   config.use_transactional_tests = false if config.respond_to?(:use_transactional_tests=)
-end
 
+  config.before(:each) do
+    # Clear PostgreSQL tables
+    ActiveRecord::Base.connection.execute("TRUNCATE users, companies, authors, books RESTART IDENTITY CASCADE")
+
+    # Clear DynamoDB audit records
+    Audited::DynamoAudit.all.each(&:delete)
+  end
+end

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Migration.verbose = false
 ActiveRecord::Base.establish_connection
 
 ActiveRecord::Schema.define do
-  create_table :users do |t|
+  create_table :users, force: :cascade do |t|
     t.column :name, :string
     t.column :username, :string
     t.column :password, :string
@@ -48,24 +48,25 @@ ActiveRecord::Schema.define do
     t.column :favourite_device, :string
     t.column :ssn, :integer
     t.column :phone_numbers, :string
+    t.column :hired_on, :date
   end
 
-  create_table :companies do |t|
+  create_table :companies, force: :cascade do |t|
     t.column :name, :string
     t.column :owner_id, :integer
     t.column :type, :string
   end
 
-  create_table :authors do |t|
+  create_table :authors, force: :cascade do |t|
     t.column :name, :string
   end
 
-  create_table :books do |t|
+  create_table :books, force: :cascade do |t|
     t.column :authord_id, :integer
     t.column :title, :string
   end
 
-  create_table :audits do |t|
+  create_table :audits, force: :cascade do |t|
     t.column :auditable_id, :integer
     t.column :auditable_type, :string
     t.column :associated_id, :integer


### PR DESCRIPTION
### Description

This pull request introduces the following changes:

- Adds support for Rails 8.0 and 8.1 compatibility.
- Refactors callback handling to streamline functionality.
- Optimizes database query usage for improved performance.
- Updates documentation to reflect the 6.0.0 release with Ruby 3.4.4 and Rails 8.x support.

#### Version Management

I want to start using tag to manage the versions

I have already tagged our current main branch as version [v5.8.0](https://github.com/helloworld1812/dynamo-audited/releases/tag/v5.8.0). Moving forward, we will have a new major version starting from 6.0.0 with rails 8 and dynamoid 3.12 support.

By implementing this change:

HRIS will use this specific version (the tag) instead of a commit hash.
Ex. `gem "dynamo-audited", git: "https://github.com/helloworld1812/dynamo-audited.git", tag: 'v5.8.0'`

Using version numbers will provide much clearer semantic meaning than a hash, making it easier to understand.

To support this transition, I have already updated the repository settings to make the tags immutable (read-only).

### Checklist

- [x] Tests have been added or updated (if applicable).
- [x] Documentation has been updated (if applicable). 
- [x] Changes follow the coding and style guidelines of the project.